### PR TITLE
Add react router and pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1468,6 +1468,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+    },
     "node_modules/@types/cors": {
       "version": "2.8.17",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
@@ -4841,6 +4846,52 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/react-router": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.5.tgz",
+      "integrity": "sha512-8BUF+hZEU4/z/JD201yK6S+UYhsf58bzYIDq2NS1iGpwxSXDu7F+DeGSkIXMFBuHZB21FSiCzEcUb18cQNdRkA==",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.1.5.tgz",
+      "integrity": "sha512-/4f9+up0Qv92D3bB8iN5P1s3oHAepSGa9h5k6tpTFlixTTskJZwKGhJ6vRJ277tLD1zuaZTt95hyGWV1Z37csQ==",
+      "dependencies": {
+        "react-router": "7.1.5"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -5102,6 +5153,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -5509,6 +5565,11 @@
       "optionalDependencies": {
         "fsevents": "~2.3.3"
       }
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6439,7 +6500,8 @@
       "dependencies": {
         "@codesandbox/utils": "^1.0.2",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.1.5"
       },
       "devDependencies": {
         "@testing-library/dom": "^10.3.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "@codesandbox/utils": "^1.0.2",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.1.5"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.3.1",

--- a/packages/client/src/lib/api/fetchDDDocument.ts
+++ b/packages/client/src/lib/api/fetchDDDocument.ts
@@ -1,0 +1,25 @@
+import { API_URL } from '../functions/getApiUrl';
+
+export const fetchDBDocument = async <T>(
+  id: string,
+  apiEndpoint: string,
+  stateSetter: React.Dispatch<React.SetStateAction<T | null>>,
+  errorSetter: React.Dispatch<React.SetStateAction<string | null>>,
+  documentCollectionType: string,
+) => {
+  try {
+    const response = await fetch(`${API_URL}${apiEndpoint}/${id}`);
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    stateSetter(data);
+  } catch (error) {
+    console.error(`Error fetching ${documentCollectionType}:`, error);
+    errorSetter(`Failed to load ${documentCollectionType} data.`);
+  }
+};
+
+export default fetchDBDocument;

--- a/packages/client/src/lib/components/common/loadingData.tsx
+++ b/packages/client/src/lib/components/common/loadingData.tsx
@@ -1,0 +1,5 @@
+const LoadingData = () => {
+  return <p>Loading...</p>;
+};
+
+export default LoadingData;

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -2,9 +2,37 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './app.tsx';
 import './index.css';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import HotelPage from './pages/hotelPage.tsx';
+import NotFoundPage from './pages/notFoundPage.tsx';
+import CountryPage from './pages/countryPage.tsx';
+import CityPage from './pages/cityPage.tsx';
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+    errorElement: <NotFoundPage />,
+  },
+  {
+    path: 'hotels/:hotelId',
+    element: <HotelPage />,
+    errorElement: <NotFoundPage />,
+  },
+  {
+    path: 'country/:countryId',
+    element: <CountryPage />,
+    errorElement: <NotFoundPage />,
+  },
+  {
+    path: 'city/:cityId',
+    element: <CityPage />,
+    errorElement: <NotFoundPage />,
+  },
+]);
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </React.StrictMode>,
 );

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -15,7 +15,7 @@ const router = createBrowserRouter([
     errorElement: <NotFoundPage />,
   },
   {
-    path: 'hotels/:hotelId',
+    path: 'hotel/:hotelId',
     element: <HotelPage />,
     errorElement: <NotFoundPage />,
   },

--- a/packages/client/src/pages/cityPage.tsx
+++ b/packages/client/src/pages/cityPage.tsx
@@ -1,8 +1,9 @@
 import { useParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { CityWithId } from '../lib/types/dbTypes';
-import { API_URL } from '../lib/functions/getApiUrl';
 import { API_ENDPOINTS_V1 } from '../lib/constants/apiEndpoints';
+import fetchDBDocument from '../lib/api/fetchDDDocument';
+import LoadingData from '../lib/components/common/loadingData';
 
 const CityPage = () => {
   const { cityId } = useParams<{ cityId: string }>();
@@ -10,36 +11,18 @@ const CityPage = () => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const fetchCity = async (id: string) => {
-      try {
-        const response = await fetch(
-          `${API_URL}${API_ENDPOINTS_V1.CITY}/${id}`,
-        );
-
-        if (!response.ok) {
-          throw new Error(`HTTP error! Status: ${response.status}`);
-        }
-
-        const data = await response.json();
-        setCity(data);
-      } catch (error) {
-        console.error('Error fetching city:', error);
-        setError('Failed to load city data.');
-      }
-    };
-
     if (cityId) {
-      fetchCity(cityId);
+      fetchDBDocument(cityId, API_ENDPOINTS_V1.CITY, setCity, setError, 'city');
     }
   }, [cityId]);
 
   if (error) return <p>{error}</p>;
-  if (!city) return <p>Loading...</p>;
+  if (!city) return <LoadingData />;
 
   return (
-    <div>
+    <main>
       <h1>{city.name}</h1>
-    </div>
+    </main>
   );
 };
 

--- a/packages/client/src/pages/cityPage.tsx
+++ b/packages/client/src/pages/cityPage.tsx
@@ -1,0 +1,46 @@
+import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { CityWithId } from '../lib/types/dbTypes';
+import { API_URL } from '../lib/functions/getApiUrl';
+import { API_ENDPOINTS_V1 } from '../lib/constants/apiEndpoints';
+
+const CityPage = () => {
+  const { cityId } = useParams<{ cityId: string }>();
+  const [city, setCity] = useState<CityWithId | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchCity = async (id: string) => {
+      try {
+        const response = await fetch(
+          `${API_URL}${API_ENDPOINTS_V1.CITY}/${id}`,
+        );
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+
+        const data = await response.json();
+        setCity(data);
+      } catch (error) {
+        console.error('Error fetching city:', error);
+        setError('Failed to load city data.');
+      }
+    };
+
+    if (cityId) {
+      fetchCity(cityId);
+    }
+  }, [cityId]);
+
+  if (error) return <p>{error}</p>;
+  if (!city) return <p>Loading...</p>;
+
+  return (
+    <div>
+      <h1>{city.name}</h1>
+    </div>
+  );
+};
+
+export default CityPage;

--- a/packages/client/src/pages/countryPage.tsx
+++ b/packages/client/src/pages/countryPage.tsx
@@ -1,8 +1,9 @@
 import { useParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { CountryWithId } from '../lib/types/dbTypes';
-import { API_URL } from '../lib/functions/getApiUrl';
 import { API_ENDPOINTS_V1 } from '../lib/constants/apiEndpoints';
+import fetchDBDocument from '../lib/api/fetchDDDocument';
+import LoadingData from '../lib/components/common/loadingData';
 
 const CountryPage = () => {
   const { countryId } = useParams<{ countryId: string }>();
@@ -10,36 +11,24 @@ const CountryPage = () => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const fetchCountry = async (id: string) => {
-      try {
-        const response = await fetch(
-          `${API_URL}${API_ENDPOINTS_V1.COUNTRY}/${id}`,
-        );
-
-        if (!response.ok) {
-          throw new Error(`HTTP error! Status: ${response.status}`);
-        }
-
-        const data = await response.json();
-        setCountry(data);
-      } catch (error) {
-        console.error('Error fetching country:', error);
-        setError('Failed to load country data.');
-      }
-    };
-
     if (countryId) {
-      fetchCountry(countryId);
+      fetchDBDocument(
+        countryId,
+        API_ENDPOINTS_V1.COUNTRY,
+        setCountry,
+        setError,
+        'country',
+      );
     }
   }, [countryId]);
 
   if (error) return <p>{error}</p>;
-  if (!country) return <p>Loading...</p>;
+  if (!country) return <LoadingData />;
 
   return (
-    <div>
+    <main>
       <h1>{country.country}</h1>
-    </div>
+    </main>
   );
 };
 

--- a/packages/client/src/pages/countryPage.tsx
+++ b/packages/client/src/pages/countryPage.tsx
@@ -1,0 +1,46 @@
+import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { CountryWithId } from '../lib/types/dbTypes';
+import { API_URL } from '../lib/functions/getApiUrl';
+import { API_ENDPOINTS_V1 } from '../lib/constants/apiEndpoints';
+
+const CountryPage = () => {
+  const { countryId } = useParams<{ countryId: string }>();
+  const [country, setCountry] = useState<CountryWithId | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchCountry = async (id: string) => {
+      try {
+        const response = await fetch(
+          `${API_URL}${API_ENDPOINTS_V1.COUNTRY}/${id}`,
+        );
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+
+        const data = await response.json();
+        setCountry(data);
+      } catch (error) {
+        console.error('Error fetching country:', error);
+        setError('Failed to load country data.');
+      }
+    };
+
+    if (countryId) {
+      fetchCountry(countryId);
+    }
+  }, [countryId]);
+
+  if (error) return <p>{error}</p>;
+  if (!country) return <p>Loading...</p>;
+
+  return (
+    <div>
+      <h1>{country.country}</h1>
+    </div>
+  );
+};
+
+export default CountryPage;

--- a/packages/client/src/pages/hotelPage.tsx
+++ b/packages/client/src/pages/hotelPage.tsx
@@ -1,8 +1,9 @@
 import { useParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { HotelWithId } from '../lib/types/dbTypes';
-import { API_URL } from '../lib/functions/getApiUrl';
 import { API_ENDPOINTS_V1 } from '../lib/constants/apiEndpoints';
+import fetchDBDocument from '../lib/api/fetchDDDocument';
+import LoadingData from '../lib/components/common/loadingData';
 
 const HotelPage = () => {
   const { hotelId } = useParams<{ hotelId: string }>();
@@ -10,36 +11,24 @@ const HotelPage = () => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const fetchHotel = async (id: string) => {
-      try {
-        const response = await fetch(
-          `${API_URL}${API_ENDPOINTS_V1.HOTEL}/${id}`,
-        );
-
-        if (!response.ok) {
-          throw new Error(`HTTP error! Status: ${response.status}`);
-        }
-
-        const data = await response.json();
-        setHotel(data);
-      } catch (error) {
-        console.error('Error fetching hotel:', error);
-        setError('Failed to load hotel data.');
-      }
-    };
-
     if (hotelId) {
-      fetchHotel(hotelId);
+      fetchDBDocument(
+        hotelId,
+        API_ENDPOINTS_V1.HOTEL,
+        setHotel,
+        setError,
+        'hotel',
+      );
     }
   }, [hotelId]);
 
   if (error) return <p>{error}</p>;
-  if (!hotel) return <p>Loading...</p>;
+  if (!hotel) return <LoadingData />;
 
   return (
-    <div>
+    <main>
       <h1>{hotel.hotel_name}</h1>
-    </div>
+    </main>
   );
 };
 

--- a/packages/client/src/pages/hotelPage.tsx
+++ b/packages/client/src/pages/hotelPage.tsx
@@ -1,0 +1,46 @@
+import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { HotelWithId } from '../lib/types/dbTypes';
+import { API_URL } from '../lib/functions/getApiUrl';
+import { API_ENDPOINTS_V1 } from '../lib/constants/apiEndpoints';
+
+const HotelPage = () => {
+  const { hotelId } = useParams<{ hotelId: string }>();
+  const [hotel, setHotel] = useState<HotelWithId | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchHotel = async (id: string) => {
+      try {
+        const response = await fetch(
+          `${API_URL}${API_ENDPOINTS_V1.HOTEL}/${id}`,
+        );
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+
+        const data = await response.json();
+        setHotel(data);
+      } catch (error) {
+        console.error('Error fetching hotel:', error);
+        setError('Failed to load hotel data.');
+      }
+    };
+
+    if (hotelId) {
+      fetchHotel(hotelId);
+    }
+  }, [hotelId]);
+
+  if (error) return <p>{error}</p>;
+  if (!hotel) return <p>Loading...</p>;
+
+  return (
+    <div>
+      <h1>{hotel.hotel_name}</h1>
+    </div>
+  );
+};
+
+export default HotelPage;

--- a/packages/client/src/pages/notFoundPage.tsx
+++ b/packages/client/src/pages/notFoundPage.tsx
@@ -1,0 +1,5 @@
+const NotFoundPage = () => {
+  return <div>Sorry Something went wrong</div>;
+};
+
+export default NotFoundPage;

--- a/packages/client/src/pages/notFoundPage.tsx
+++ b/packages/client/src/pages/notFoundPage.tsx
@@ -1,5 +1,9 @@
 const NotFoundPage = () => {
-  return <div>Sorry Something went wrong</div>;
+  return (
+    <main>
+      <p>Sorry Something went wrong</p>
+    </main>
+  );
 };
 
 export default NotFoundPage;


### PR DESCRIPTION
# Description

- Adds react router and the ability to navigate to dynamic routes on hotel, country and city.
- Fetches the data for each of these pages and display some data in a heading depending on document type.


##  How to Test

- start the api and the client in separate terminals
- go to the client
- enter some text into a search bar
-  click on each entity:
1. test that you can go to a hotel page and that hotel name displays correctly and that the route is `hotel/{some-id}`
2. test that you can go to a country page and that country name displays correctly and that the route is `country/{some-id}`
3. test that you can go to a city page and that city name displays correctly and that the route is `city/{some-id}`
4. enter some random id on these routes and see that you get a 'data failed to load' message
5. go to a route that does not exist e.g. `/tom` and see that you get the 404 page message